### PR TITLE
Changed class name from .title to .title-punch

### DIFF
--- a/src/Components/CSS/PunchCard.css
+++ b/src/Components/CSS/PunchCard.css
@@ -111,21 +111,20 @@ h1{
         display: inline-flex;
         justify-content: center;
     }
-    .punch-body{
-        display: unset;
-    }
     .container-child{
         border-style: none;
         width: unset;
         padding: 0;
+        height: auto;
+        visibility: initial;
+        clip-path: none;
     }
     .container-child-content{
         width: unset;
         
     }
 
-    .container-parent, .container-child{
-
-        height: auto;
+    .container-parent{
+      visibility: hidden;
     }
 }

--- a/src/Components/CSS/PunchCard.css
+++ b/src/Components/CSS/PunchCard.css
@@ -69,7 +69,7 @@ h1{
         width: 48px;
       }
     }
-    .title {
+    .title-punch {
       padding-left: 48px;
       text-align: left;
       font-size: 24px;

--- a/src/Components/PunchCard.jsx
+++ b/src/Components/PunchCard.jsx
@@ -14,21 +14,21 @@ function PunchCard() {
               <div className="container-child-content">
                 <table id="punches" className="rounded-table no-color">
                   <tr>
-                    <td className="title">Breakfast</td>
+                    <td className="title-punch">Breakfast</td>
                     <td><div className="punch true"></div></td>
                     <td><div className="punch false"/></td>
                     <td><div className="punch false"/></td>
                     <td className="spacer"></td>
                   </tr>
                   <tr>
-                    <td className="title">Lunch</td>
+                    <td className="title-punch">Lunch</td>
                     <td><div className="punch true"></div></td>
                     <td><div className="punch true"></div></td>
                     <td><div className="punch false"/></td>
                     <td className="spacer"></td>
                   </tr>
                   <tr>
-                    <td className="title">Dinner</td>
+                    <td className="title-punch">Dinner</td>
                     <td><div className="punch true"></div></td>
                     <td><div className="punch true"></div></td>
                     <td><div className="punch false"/></td>


### PR DESCRIPTION
This should fix the issue that was causing the title text to be 5em, as that code was somehow affecting this one through the usage of .title class. I renamed .title to .title-punch. Please test this on MacOS/iOS.
![image](https://github.com/user-attachments/assets/c252dc9e-cd22-4bfe-9b2f-abb6ae17974b)

Thank you